### PR TITLE
Add Quirk For Konke Contact Sensor for Battery

### DIFF
--- a/zhaquirks/konke/magnet.py
+++ b/zhaquirks/konke/magnet.py
@@ -1,0 +1,67 @@
+"""Konke magnet sensor."""
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.security import IasZone
+from zigpy.zcl.clusters.general import Basic, Identify, PowerConfiguration
+
+from . import KONKE
+from .. import PowerConfigurationCluster
+from ..const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+KONKE_CLUSTER_ID = 0xFCC0
+
+class KonkeMagnet(CustomDevice):
+    """Custom device representing konke magnet sensors."""
+
+    signature = {
+        #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026
+        # device_version=0
+        # input_clusters=[0, 1, 3, 1280, 64704]
+        # output_clusters=[3, 64704]>
+        MODELS_INFO: [(KONKE, "3AFE270104020015")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    IasZone.cluster_id,
+                    KONKE_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    KONKE_CLUSTER_ID,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfigurationCluster,
+                    Identify.cluster_id,
+                    IasZone.cluster_id,
+                    KONKE_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    KONKE_CLUSTER_ID,
+                ],
+            }
+        }
+    }


### PR DESCRIPTION
Added a new quirk for the Konke 3AFE270104020015 contact sensor so it can report battery percentage in HA.  Tested and working with sensor I just received recently.  Is there any way to set the battery size via quirk - temp sensor also shows unkown for battery size?  (Its a 3v CR1632 for the sensor.)

<img width="905" alt="Screen Shot 2020-05-25 at 11 39 22 PM" src="https://user-images.githubusercontent.com/11084412/82858409-cd744200-9ee1-11ea-92dc-aa30f9427c64.png">
